### PR TITLE
fix: support linked Git worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
       },
       "autoRestage": true
     },
-    "commit-msg": "bunx gitlint --edit .git/COMMIT_EDITMSG"
+    "commit-msg": "bunx gitlint --edit \"$(git rev-parse --git-path COMMIT_EDITMSG)\""
   },
   "overrides": {
     "typescript": "^7.0.2"

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,13 +1,14 @@
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import process from 'node:process'
 
 /**
  * Find the Git repository root directory
  */
-function findGitRoot(): string | null {
+function findGitRoot(cwd: string): string | null {
   try {
-    const gitRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim()
+    const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd, encoding: 'utf8' }).trim()
     return gitRoot
   }
   // eslint-disable-next-line unused-imports/no-unused-vars
@@ -16,18 +17,32 @@ function findGitRoot(): string | null {
   }
 }
 
+/** Resolve the effective hooks directory for main checkouts and linked worktrees. */
+export function resolveHooksDirectory(cwd: string = process.cwd()): string | null {
+  try {
+    const hooksPath = execFileSync('git', ['rev-parse', '--git-path', 'hooks'], {
+      cwd,
+      encoding: 'utf8',
+    }).trim()
+    return path.resolve(cwd, hooksPath)
+  }
+  catch {
+    return null
+  }
+}
+
 /**
  * Install Git hooks for the current repository
  */
-export function installGitHooks(force = false): boolean {
-  const gitRoot = findGitRoot()
+export function installGitHooks(force = false, cwd: string = process.cwd()): boolean {
+  const gitRoot = findGitRoot(cwd)
   if (!gitRoot) {
     console.error('Not a git repository')
     return false
   }
 
-  const hooksDir = path.join(gitRoot, '.git', 'hooks')
-  if (!fs.existsSync(hooksDir)) {
+  const hooksDir = resolveHooksDirectory(cwd)
+  if (!hooksDir || !fs.existsSync(hooksDir)) {
     console.error(`Git hooks directory not found: ${hooksDir}`)
     return false
   }
@@ -63,14 +78,19 @@ gitlint --edit "$1"
 /**
  * Uninstall Git hooks for the current repository
  */
-export function uninstallGitHooks(): boolean {
-  const gitRoot = findGitRoot()
+export function uninstallGitHooks(cwd: string = process.cwd()): boolean {
+  const gitRoot = findGitRoot(cwd)
   if (!gitRoot) {
     console.error('Not a git repository')
     return false
   }
 
-  const commitMsgHookPath = path.join(gitRoot, '.git', 'hooks', 'commit-msg')
+  const hooksDir = resolveHooksDirectory(cwd)
+  if (!hooksDir) {
+    console.error('Git hooks directory could not be resolved')
+    return false
+  }
+  const commitMsgHookPath = path.join(hooksDir, 'commit-msg')
   if (!fs.existsSync(commitMsgHookPath)) {
     console.error('No commit-msg hook found')
     return true

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,35 @@
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 
+/** Resolve a path below `.git` through Git so linked worktrees are supported. */
+export function resolveCommitMessagePath(filePath: string, cwd: string = process.cwd()): string {
+  const absolutePath = path.resolve(cwd, filePath)
+  const relativePath = path.relative(cwd, absolutePath).split(path.sep).join('/')
+  if (relativePath !== '.git' && !relativePath.startsWith('.git/')) return absolutePath
+
+  const gitPath = relativePath === '.git' ? '' : relativePath.slice('.git/'.length)
+  if (!gitPath) return absolutePath
+
+  try {
+    const resolved = execFileSync('git', ['rev-parse', '--git-path', gitPath], {
+      cwd,
+      encoding: 'utf8',
+    }).trim()
+    return path.resolve(cwd, resolved)
+  }
+  catch {
+    return absolutePath
+  }
+}
+
 /**
  * Read the commit message from a file
  */
-export function readCommitMessageFromFile(filePath: string): string {
+export function readCommitMessageFromFile(filePath: string, cwd: string = process.cwd()): string {
   try {
-    return fs.readFileSync(path.resolve(process.cwd(), filePath), 'utf8')
+    return fs.readFileSync(resolveCommitMessagePath(filePath, cwd), 'utf8')
   }
   catch (error: unknown) {
     console.error(`Error reading commit message file: ${filePath}`)

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { installGitHooks, resolveHooksDirectory, uninstallGitHooks } from '../src/hooks'
+import { readCommitMessageFromFile, resolveCommitMessagePath } from '../src/utils'
+
+const temporaryRoots: string[] = []
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}
+
+function linkedWorktree(): { repository: string, worktree: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitlint-worktree-'))
+  temporaryRoots.push(root)
+  const repository = path.join(root, 'repository')
+  const worktree = path.join(root, 'linked')
+  fs.mkdirSync(repository)
+  git(repository, 'init', '--initial-branch=main')
+  git(repository, 'config', 'user.name', 'Gitlint Test')
+  git(repository, 'config', 'user.email', 'gitlint@example.com')
+  fs.writeFileSync(path.join(repository, 'README.md'), '# fixture\n')
+  git(repository, 'add', 'README.md')
+  git(repository, 'commit', '-m', 'chore: initialize fixture')
+  git(repository, 'worktree', 'add', '-b', 'test-worktree', worktree)
+  return { repository, worktree }
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('linked worktree support', () => {
+  it('resolves .git commit message paths through Git', () => {
+    const { worktree } = linkedWorktree()
+    expect(fs.statSync(path.join(worktree, '.git')).isFile()).toBeTrue()
+    const actualPath = path.resolve(worktree, git(worktree, 'rev-parse', '--git-path', 'COMMIT_EDITMSG'))
+    fs.writeFileSync(actualPath, 'feat: support linked worktrees\n')
+
+    expect(resolveCommitMessagePath('.git/COMMIT_EDITMSG', worktree)).toBe(actualPath)
+    expect(readCommitMessageFromFile('.git/COMMIT_EDITMSG', worktree)).toBe('feat: support linked worktrees\n')
+  })
+
+  it('installs and removes hooks in the effective Git hooks directory', () => {
+    const { worktree } = linkedWorktree()
+    const hooksDirectory = path.resolve(worktree, git(worktree, 'rev-parse', '--git-path', 'hooks'))
+    const hookPath = path.join(hooksDirectory, 'commit-msg')
+
+    expect(resolveHooksDirectory(worktree)).toBe(hooksDirectory)
+    expect(installGitHooks(true, worktree)).toBeTrue()
+    expect(fs.readFileSync(hookPath, 'utf8')).toContain('gitlint --edit "$1"')
+    expect(uninstallGitHooks(worktree)).toBeTrue()
+    expect(fs.existsSync(hookPath)).toBeFalse()
+  })
+
+  it('preserves ordinary absolute and relative paths', () => {
+    const { worktree } = linkedWorktree()
+    const relativePath = 'message.txt'
+    const absolutePath = path.join(worktree, relativePath)
+    fs.writeFileSync(absolutePath, 'fix: ordinary path\n')
+
+    expect(resolveCommitMessagePath(relativePath, worktree)).toBe(absolutePath)
+    expect(resolveCommitMessagePath(absolutePath, worktree)).toBe(absolutePath)
+  })
+})


### PR DESCRIPTION
## What changed

- resolve `.git/*` commit-message paths through `git rev-parse --git-path`
- resolve the effective hooks directory for main checkouts and linked worktrees
- install and remove hooks through that resolved directory
- make this repository's own commit-msg hook worktree-safe
- add real linked-worktree integration tests

## Why

Git worktrees use a `.git` pointer file. Treating it as a directory caused `gitlint --edit .git/COMMIT_EDITMSG` to fail with `ENOTDIR`, blocking valid commits in downstream Stacks worktrees.

Closes #550.

## Validation

- `bun run build`
- `bun test`: 47 passed
- `bun run typecheck`
- `bun run lint`: 0 errors, 7 existing documentation warnings
- this commit itself passed the regenerated worktree-safe commit-msg hook
